### PR TITLE
fix: remove omitempty on bool fields and fix GetMonitor response parsing

### DIFF
--- a/internal/monitor/dns_monitor_resource.go
+++ b/internal/monitor/dns_monitor_resource.go
@@ -159,8 +159,8 @@ type dnsMonitorAPIObject struct {
 	Timeout          jsonInt64             `json:"timeout,omitempty"`
 	DegradedAt       jsonInt64             `json:"degradedAt,omitempty"`
 	Retry            jsonInt64             `json:"retry,omitempty"`
-	Active           bool                  `json:"active,omitempty"`
-	Public           bool                  `json:"public,omitempty"`
+	Active           bool                  `json:"active"`
+	Public           bool                  `json:"public"`
 	Description      string                `json:"description,omitempty"`
 	Regions          []string              `json:"regions,omitempty"`
 	RecordAssertions []apiRecordAssertion  `json:"recordAssertions,omitempty"`
@@ -230,12 +230,12 @@ func (r *dnsMonitorResource) Read(ctx context.Context, req resource.ReadRequest,
 		return
 	}
 
-	if apiResp.DNS == nil {
+	if apiResp.Monitor.DNS == nil {
 		resp.State.RemoveResource(ctx)
 		return
 	}
 
-	resp.Diagnostics.Append(dnsAPIToModel(ctx, *apiResp.DNS, &data)...)
+	resp.Diagnostics.Append(dnsAPIToModel(ctx, *apiResp.Monitor.DNS, &data)...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 

--- a/internal/monitor/dns_monitor_resource_test.go
+++ b/internal/monitor/dns_monitor_resource_test.go
@@ -1,0 +1,53 @@
+package monitor
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestDNSMonitorAPIObject_BoolFalseNotOmitted(t *testing.T) {
+	obj := dnsMonitorAPIObject{
+		Name:        "test",
+		URI:         "example.com",
+		Periodicity: "PERIODICITY_1M",
+		Active:      false,
+		Public:      false,
+	}
+
+	data, err := json.Marshal(obj)
+	if err != nil {
+		t.Fatalf("unexpected marshal error: %v", err)
+	}
+
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("unexpected unmarshal error: %v", err)
+	}
+
+	for _, field := range []string{"active", "public"} {
+		val, ok := raw[field]
+		if !ok {
+			t.Errorf("field %q omitted from JSON when false — omitempty must be removed", field)
+			continue
+		}
+		if val != false {
+			t.Errorf("field %q = %v, want false", field, val)
+		}
+	}
+}
+
+func TestGetMonitorResponse_NestedMonitorWrapper_DNS(t *testing.T) {
+	apiJSON := `{"monitor":{"dns":{"name":"DNS Check","uri":"example.com"}}}`
+
+	var resp getMonitorResponse
+	if err := json.Unmarshal([]byte(apiJSON), &resp); err != nil {
+		t.Fatalf("unexpected unmarshal error: %v", err)
+	}
+
+	if resp.Monitor.DNS == nil {
+		t.Fatal("expected monitor.dns to be parsed, got nil")
+	}
+	if resp.Monitor.DNS.Name != "DNS Check" {
+		t.Errorf("name = %q, want %q", resp.Monitor.DNS.Name, "DNS Check")
+	}
+}

--- a/internal/monitor/http_monitor_resource.go
+++ b/internal/monitor/http_monitor_resource.go
@@ -260,9 +260,9 @@ type httpMonitorAPIObject struct {
 	Timeout              jsonInt64                    `json:"timeout,omitempty"`
 	DegradedAt           jsonInt64                    `json:"degradedAt,omitempty"`
 	Retry                jsonInt64                    `json:"retry,omitempty"`
-	FollowRedirects      bool                         `json:"followRedirects,omitempty"`
-	Active               bool                         `json:"active,omitempty"`
-	Public               bool                         `json:"public,omitempty"`
+	FollowRedirects      bool                         `json:"followRedirects"`
+	Active               bool                         `json:"active"`
+	Public               bool                         `json:"public"`
 	Description          string                       `json:"description,omitempty"`
 	Regions              []string                     `json:"regions,omitempty"`
 	Headers              []apiHeader                  `json:"headers,omitempty"`
@@ -297,10 +297,14 @@ type httpMonitorAPIResponse struct {
 	Monitor httpMonitorAPIObject `json:"monitor"`
 }
 
-type getMonitorResponse struct {
+type getMonitorResponseInner struct {
 	HTTP *httpMonitorAPIObject `json:"http,omitempty"`
 	TCP  *tcpMonitorAPIObject  `json:"tcp,omitempty"`
 	DNS  *dnsMonitorAPIObject  `json:"dns,omitempty"`
+}
+
+type getMonitorResponse struct {
+	Monitor getMonitorResponseInner `json:"monitor"`
 }
 
 func (r *httpMonitorResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
@@ -345,12 +349,12 @@ func (r *httpMonitorResource) Read(ctx context.Context, req resource.ReadRequest
 		return
 	}
 
-	if apiResp.HTTP == nil {
+	if apiResp.Monitor.HTTP == nil {
 		resp.State.RemoveResource(ctx)
 		return
 	}
 
-	resp.Diagnostics.Append(httpAPIToModel(ctx, *apiResp.HTTP, &data)...)
+	resp.Diagnostics.Append(httpAPIToModel(ctx, *apiResp.Monitor.HTTP, &data)...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 

--- a/internal/monitor/http_monitor_resource_test.go
+++ b/internal/monitor/http_monitor_resource_test.go
@@ -1,0 +1,58 @@
+package monitor
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestHTTPMonitorAPIObject_BoolFalseNotOmitted(t *testing.T) {
+	obj := httpMonitorAPIObject{
+		Name:            "test",
+		URL:             "https://example.com",
+		Periodicity:     "PERIODICITY_1M",
+		FollowRedirects: false,
+		Active:          false,
+		Public:          false,
+	}
+
+	data, err := json.Marshal(obj)
+	if err != nil {
+		t.Fatalf("unexpected marshal error: %v", err)
+	}
+
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("unexpected unmarshal error: %v", err)
+	}
+
+	for _, field := range []string{"followRedirects", "active", "public"} {
+		val, ok := raw[field]
+		if !ok {
+			t.Errorf("field %q omitted from JSON when false — omitempty must be removed", field)
+			continue
+		}
+		if val != false {
+			t.Errorf("field %q = %v, want false", field, val)
+		}
+	}
+}
+
+func TestGetMonitorResponse_NestedMonitorWrapper(t *testing.T) {
+	// Simulates the actual API v2 response format
+	apiJSON := `{"monitor":{"http":{"name":"Hub UI","url":"https://hub.traefik.io","followRedirects":false}}}`
+
+	var resp getMonitorResponse
+	if err := json.Unmarshal([]byte(apiJSON), &resp); err != nil {
+		t.Fatalf("unexpected unmarshal error: %v", err)
+	}
+
+	if resp.Monitor.HTTP == nil {
+		t.Fatal("expected monitor.http to be parsed, got nil")
+	}
+	if resp.Monitor.HTTP.Name != "Hub UI" {
+		t.Errorf("name = %q, want %q", resp.Monitor.HTTP.Name, "Hub UI")
+	}
+	if resp.Monitor.HTTP.FollowRedirects != false {
+		t.Error("followRedirects = true, want false")
+	}
+}

--- a/internal/monitor/monitor_data_source.go
+++ b/internal/monitor/monitor_data_source.go
@@ -85,42 +85,42 @@ func (d *monitorDataSource) Read(ctx context.Context, req datasource.ReadRequest
 	}
 
 	switch {
-	case apiResp.HTTP != nil:
+	case apiResp.Monitor.HTTP != nil:
 		data.Type = types.StringValue("http")
-		data.Name = types.StringValue(apiResp.HTTP.Name)
-		data.URL = types.StringValue(apiResp.HTTP.URL)
-		data.Periodicity = types.StringValue(MapPeriodicityFromAPI(apiResp.HTTP.Periodicity))
-		data.Method = types.StringValue(MapMethodFromAPI(apiResp.HTTP.Method))
-		data.Active = types.BoolValue(apiResp.HTTP.Active)
-		data.Public = types.BoolValue(apiResp.HTTP.Public)
-		data.Description = types.StringValue(apiResp.HTTP.Description)
-		data.Timeout = types.Int64Value(apiResp.HTTP.Timeout.Int64())
-		if apiResp.HTTP.Status != "" {
-			data.Status = types.StringValue(MapMonitorStatusFromAPI(apiResp.HTTP.Status))
+		data.Name = types.StringValue(apiResp.Monitor.HTTP.Name)
+		data.URL = types.StringValue(apiResp.Monitor.HTTP.URL)
+		data.Periodicity = types.StringValue(MapPeriodicityFromAPI(apiResp.Monitor.HTTP.Periodicity))
+		data.Method = types.StringValue(MapMethodFromAPI(apiResp.Monitor.HTTP.Method))
+		data.Active = types.BoolValue(apiResp.Monitor.HTTP.Active)
+		data.Public = types.BoolValue(apiResp.Monitor.HTTP.Public)
+		data.Description = types.StringValue(apiResp.Monitor.HTTP.Description)
+		data.Timeout = types.Int64Value(apiResp.Monitor.HTTP.Timeout.Int64())
+		if apiResp.Monitor.HTTP.Status != "" {
+			data.Status = types.StringValue(MapMonitorStatusFromAPI(apiResp.Monitor.HTTP.Status))
 		}
-	case apiResp.TCP != nil:
+	case apiResp.Monitor.TCP != nil:
 		data.Type = types.StringValue("tcp")
-		data.Name = types.StringValue(apiResp.TCP.Name)
-		data.URI = types.StringValue(apiResp.TCP.URI)
-		data.Periodicity = types.StringValue(MapPeriodicityFromAPI(apiResp.TCP.Periodicity))
-		data.Active = types.BoolValue(apiResp.TCP.Active)
-		data.Public = types.BoolValue(apiResp.TCP.Public)
-		data.Description = types.StringValue(apiResp.TCP.Description)
-		data.Timeout = types.Int64Value(apiResp.TCP.Timeout.Int64())
-		if apiResp.TCP.Status != "" {
-			data.Status = types.StringValue(MapMonitorStatusFromAPI(apiResp.TCP.Status))
+		data.Name = types.StringValue(apiResp.Monitor.TCP.Name)
+		data.URI = types.StringValue(apiResp.Monitor.TCP.URI)
+		data.Periodicity = types.StringValue(MapPeriodicityFromAPI(apiResp.Monitor.TCP.Periodicity))
+		data.Active = types.BoolValue(apiResp.Monitor.TCP.Active)
+		data.Public = types.BoolValue(apiResp.Monitor.TCP.Public)
+		data.Description = types.StringValue(apiResp.Monitor.TCP.Description)
+		data.Timeout = types.Int64Value(apiResp.Monitor.TCP.Timeout.Int64())
+		if apiResp.Monitor.TCP.Status != "" {
+			data.Status = types.StringValue(MapMonitorStatusFromAPI(apiResp.Monitor.TCP.Status))
 		}
-	case apiResp.DNS != nil:
+	case apiResp.Monitor.DNS != nil:
 		data.Type = types.StringValue("dns")
-		data.Name = types.StringValue(apiResp.DNS.Name)
-		data.URI = types.StringValue(apiResp.DNS.URI)
-		data.Periodicity = types.StringValue(MapPeriodicityFromAPI(apiResp.DNS.Periodicity))
-		data.Active = types.BoolValue(apiResp.DNS.Active)
-		data.Public = types.BoolValue(apiResp.DNS.Public)
-		data.Description = types.StringValue(apiResp.DNS.Description)
-		data.Timeout = types.Int64Value(apiResp.DNS.Timeout.Int64())
-		if apiResp.DNS.Status != "" {
-			data.Status = types.StringValue(MapMonitorStatusFromAPI(apiResp.DNS.Status))
+		data.Name = types.StringValue(apiResp.Monitor.DNS.Name)
+		data.URI = types.StringValue(apiResp.Monitor.DNS.URI)
+		data.Periodicity = types.StringValue(MapPeriodicityFromAPI(apiResp.Monitor.DNS.Periodicity))
+		data.Active = types.BoolValue(apiResp.Monitor.DNS.Active)
+		data.Public = types.BoolValue(apiResp.Monitor.DNS.Public)
+		data.Description = types.StringValue(apiResp.Monitor.DNS.Description)
+		data.Timeout = types.Int64Value(apiResp.Monitor.DNS.Timeout.Int64())
+		if apiResp.Monitor.DNS.Status != "" {
+			data.Status = types.StringValue(MapMonitorStatusFromAPI(apiResp.Monitor.DNS.Status))
 		}
 	default:
 		resp.Diagnostics.AddError("Monitor not found", "No monitor returned for ID: "+data.ID.ValueString())

--- a/internal/monitor/tcp_monitor_resource.go
+++ b/internal/monitor/tcp_monitor_resource.go
@@ -130,8 +130,8 @@ type tcpMonitorAPIObject struct {
 	Timeout     jsonInt64 `json:"timeout,omitempty"`
 	DegradedAt  jsonInt64 `json:"degradedAt,omitempty"`
 	Retry       jsonInt64 `json:"retry,omitempty"`
-	Active      bool     `json:"active,omitempty"`
-	Public      bool     `json:"public,omitempty"`
+	Active      bool     `json:"active"`
+	Public      bool     `json:"public"`
 	Description string   `json:"description,omitempty"`
 	Regions     []string `json:"regions,omitempty"`
 	Status      string   `json:"status,omitempty"`
@@ -194,12 +194,12 @@ func (r *tcpMonitorResource) Read(ctx context.Context, req resource.ReadRequest,
 		return
 	}
 
-	if apiResp.TCP == nil {
+	if apiResp.Monitor.TCP == nil {
 		resp.State.RemoveResource(ctx)
 		return
 	}
 
-	resp.Diagnostics.Append(tcpAPIToModel(ctx, *apiResp.TCP, &data)...)
+	resp.Diagnostics.Append(tcpAPIToModel(ctx, *apiResp.Monitor.TCP, &data)...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 

--- a/internal/monitor/tcp_monitor_resource_test.go
+++ b/internal/monitor/tcp_monitor_resource_test.go
@@ -1,0 +1,53 @@
+package monitor
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestTCPMonitorAPIObject_BoolFalseNotOmitted(t *testing.T) {
+	obj := tcpMonitorAPIObject{
+		Name:        "test",
+		URI:         "example.com:443",
+		Periodicity: "PERIODICITY_1M",
+		Active:      false,
+		Public:      false,
+	}
+
+	data, err := json.Marshal(obj)
+	if err != nil {
+		t.Fatalf("unexpected marshal error: %v", err)
+	}
+
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("unexpected unmarshal error: %v", err)
+	}
+
+	for _, field := range []string{"active", "public"} {
+		val, ok := raw[field]
+		if !ok {
+			t.Errorf("field %q omitted from JSON when false — omitempty must be removed", field)
+			continue
+		}
+		if val != false {
+			t.Errorf("field %q = %v, want false", field, val)
+		}
+	}
+}
+
+func TestGetMonitorResponse_NestedMonitorWrapper_TCP(t *testing.T) {
+	apiJSON := `{"monitor":{"tcp":{"name":"Orbula","uri":"v3.license.containous.cloud:443"}}}`
+
+	var resp getMonitorResponse
+	if err := json.Unmarshal([]byte(apiJSON), &resp); err != nil {
+		t.Fatalf("unexpected unmarshal error: %v", err)
+	}
+
+	if resp.Monitor.TCP == nil {
+		t.Fatal("expected monitor.tcp to be parsed, got nil")
+	}
+	if resp.Monitor.TCP.Name != "Orbula" {
+		t.Errorf("name = %q, want %q", resp.Monitor.TCP.Name, "Orbula")
+	}
+}


### PR DESCRIPTION
# Description

Fixes two bugs introduced in v0.0.9:

**1. `omitempty` on bool fields drops `false` values**

`followRedirects`, `active`, and `public` fields in the API structs use `json:",omitempty"`. In Go, `omitempty` omits the zero value for bools (`false`), so the API never receives `false` and defaults to `true`. For example, setting `follow_redirects = false` in Terraform has no effect.

Fix: remove `omitempty` from all bool fields in HTTP, TCP, and DNS monitor API structs.

**2. `GetMonitor` response not parsed correctly**

The API returns `{"monitor": {"http": {...}}}` but the provider expected `{"http": {...}}` (missing the `monitor` wrapper). This breaks `terraform import` and `terraform plan` refresh — imported resources appear empty and Terraform wants to recreate them.

Fix: add the `monitor` wrapper struct to `getMonitorResponse`.