### PR TITLE
feat: add group_order attribute to status page component

### DIFF
--- a/internal/statuspage/component_resource.go
+++ b/internal/statuspage/component_resource.go
@@ -39,6 +39,7 @@ type componentModel struct {
 	Description types.String `tfsdk:"description"`
 	Order       types.Int64  `tfsdk:"order"`
 	GroupID     types.String `tfsdk:"group_id"`
+	GroupOrder  types.Int64  `tfsdk:"group_order"`
 	CreatedAt   types.String `tfsdk:"created_at"`
 	UpdatedAt   types.String `tfsdk:"updated_at"`
 }
@@ -84,11 +85,17 @@ func (r *componentResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 				Validators: []validator.String{stringvalidator.LengthAtMost(1024)},
 			},
 			"order": schema.Int64Attribute{
-				Optional: true,
-				Computed: true,
+				Optional:            true,
+				Computed:            true,
+				MarkdownDescription: "Display order of the component's group on the status page.",
 			},
 			"group_id": schema.StringAttribute{
 				Optional: true,
+			},
+			"group_order": schema.Int64Attribute{
+				Optional:            true,
+				Computed:            true,
+				MarkdownDescription: "Display order of the component within its group.",
 			},
 			"created_at": schema.StringAttribute{Computed: true},
 			"updated_at": schema.StringAttribute{Computed: true},
@@ -101,16 +108,18 @@ type apiAddMonitorComponentRequest struct {
 	MonitorID   string `json:"monitorId"`
 	Name        string `json:"name,omitempty"`
 	Description string `json:"description,omitempty"`
-	Order       int64  `json:"order,omitempty"`
+	Order       *int64 `json:"order,omitempty"`
 	GroupID     string `json:"groupId,omitempty"`
+	GroupOrder  *int64 `json:"groupOrder,omitempty"`
 }
 
 type apiAddStaticComponentRequest struct {
 	PageID      string `json:"pageId"`
 	Name        string `json:"name"`
 	Description string `json:"description,omitempty"`
-	Order       int64  `json:"order,omitempty"`
+	Order       *int64 `json:"order,omitempty"`
 	GroupID     string `json:"groupId,omitempty"`
+	GroupOrder  *int64 `json:"groupOrder,omitempty"`
 }
 
 type apiComponentResponse struct {
@@ -126,6 +135,7 @@ type apiComponent struct {
 	MonitorID   string `json:"monitorId"`
 	Order       int64  `json:"order"`
 	GroupID     string `json:"groupId"`
+	GroupOrder  int64  `json:"groupOrder"`
 	CreatedAt   string `json:"createdAt"`
 	UpdatedAt   string `json:"updatedAt"`
 }
@@ -136,6 +146,7 @@ type apiUpdateComponentRequest struct {
 	Description *string `json:"description,omitempty"`
 	Order       *int64  `json:"order,omitempty"`
 	GroupID     *string `json:"groupId,omitempty"`
+	GroupOrder  *int64  `json:"groupOrder,omitempty"`
 }
 
 type apiStatusPageContentResponse struct {
@@ -160,8 +171,15 @@ func (r *componentResource) Create(ctx context.Context, req resource.CreateReque
 			MonitorID:   data.MonitorID.ValueString(),
 			Name:        data.Name.ValueString(),
 			Description: data.Description.ValueString(),
-			Order:       data.Order.ValueInt64(),
 			GroupID:     data.GroupID.ValueString(),
+		}
+		if !data.Order.IsNull() && !data.Order.IsUnknown() {
+			v := data.Order.ValueInt64()
+			apiReq.Order = &v
+		}
+		if !data.GroupOrder.IsNull() && !data.GroupOrder.IsUnknown() {
+			v := data.GroupOrder.ValueInt64()
+			apiReq.GroupOrder = &v
 		}
 		err = r.client.Do(ctx, "/openstatus.status_page.v1.StatusPageService/AddMonitorComponent", apiReq, &apiResp)
 	} else {
@@ -169,8 +187,15 @@ func (r *componentResource) Create(ctx context.Context, req resource.CreateReque
 			PageID:      data.PageID.ValueString(),
 			Name:        data.Name.ValueString(),
 			Description: data.Description.ValueString(),
-			Order:       data.Order.ValueInt64(),
 			GroupID:     data.GroupID.ValueString(),
+		}
+		if !data.Order.IsNull() && !data.Order.IsUnknown() {
+			v := data.Order.ValueInt64()
+			apiReq.Order = &v
+		}
+		if !data.GroupOrder.IsNull() && !data.GroupOrder.IsUnknown() {
+			v := data.GroupOrder.ValueInt64()
+			apiReq.GroupOrder = &v
 		}
 		err = r.client.Do(ctx, "/openstatus.status_page.v1.StatusPageService/AddStaticComponent", apiReq, &apiResp)
 	}
@@ -235,9 +260,13 @@ func (r *componentResource) Update(ctx context.Context, req resource.UpdateReque
 		v := data.Order.ValueInt64()
 		updateReq.Order = &v
 	}
-	if !data.GroupID.IsNull() {
+	if !data.GroupID.IsNull() && !data.GroupID.IsUnknown() {
 		v := data.GroupID.ValueString()
 		updateReq.GroupID = &v
+	}
+	if !data.GroupOrder.IsNull() && !data.GroupOrder.IsUnknown() {
+		v := data.GroupOrder.ValueInt64()
+		updateReq.GroupOrder = &v
 	}
 
 	var apiResp apiComponentResponse
@@ -300,6 +329,7 @@ func componentAPIToModel(api apiComponent, data *componentModel) {
 		data.Description = types.StringValue(api.Description)
 	}
 	data.Order = types.Int64Value(api.Order)
+	data.GroupOrder = types.Int64Value(api.GroupOrder)
 	if api.GroupID != "" {
 		data.GroupID = types.StringValue(api.GroupID)
 	}

--- a/internal/statuspage/component_resource_test.go
+++ b/internal/statuspage/component_resource_test.go
@@ -1,0 +1,188 @@
+package statuspage
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func ptr[T any](v T) *T { return &v }
+
+func TestAPIAddMonitorComponentRequest_IncludesGroupOrder(t *testing.T) {
+	req := apiAddMonitorComponentRequest{
+		PageID:     "1",
+		MonitorID:  "42",
+		Name:       "Hub UI",
+		Order:      ptr(int64(0)),
+		GroupID:    "10",
+		GroupOrder: ptr(int64(3)),
+	}
+
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("unexpected marshal error: %v", err)
+	}
+
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("unexpected unmarshal error: %v", err)
+	}
+
+	val, ok := raw["groupOrder"]
+	if !ok {
+		t.Fatal("groupOrder field missing from JSON")
+	}
+	if val != float64(3) {
+		t.Errorf("groupOrder = %v, want 3", val)
+	}
+}
+
+func TestAPIAddMonitorComponentRequest_OmitsNilGroupOrder(t *testing.T) {
+	req := apiAddMonitorComponentRequest{
+		PageID:    "1",
+		MonitorID: "42",
+		Name:      "Hub UI",
+	}
+
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("unexpected marshal error: %v", err)
+	}
+
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("unexpected unmarshal error: %v", err)
+	}
+
+	if _, ok := raw["groupOrder"]; ok {
+		t.Error("groupOrder should be omitted when nil")
+	}
+	if _, ok := raw["order"]; ok {
+		t.Error("order should be omitted when nil")
+	}
+}
+
+func TestAPIAddStaticComponentRequest_IncludesGroupOrder(t *testing.T) {
+	req := apiAddStaticComponentRequest{
+		PageID:     "1",
+		Name:       "Static",
+		Order:      ptr(int64(1)),
+		GroupID:    "10",
+		GroupOrder: ptr(int64(2)),
+	}
+
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("unexpected marshal error: %v", err)
+	}
+
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("unexpected unmarshal error: %v", err)
+	}
+
+	val, ok := raw["groupOrder"]
+	if !ok {
+		t.Fatal("groupOrder field missing from JSON")
+	}
+	if val != float64(2) {
+		t.Errorf("groupOrder = %v, want 2", val)
+	}
+}
+
+func TestAPIComponent_GroupOrderParsed(t *testing.T) {
+	apiJSON := `{
+		"id": "1",
+		"pageId": "2",
+		"name": "Hub UI",
+		"description": "",
+		"type": "PAGE_COMPONENT_TYPE_MONITOR",
+		"monitorId": "42",
+		"order": 0,
+		"groupId": "10",
+		"groupOrder": 3,
+		"createdAt": "2026-03-23T00:00:00Z",
+		"updatedAt": "2026-03-23T00:00:00Z"
+	}`
+
+	var comp apiComponent
+	if err := json.Unmarshal([]byte(apiJSON), &comp); err != nil {
+		t.Fatalf("unexpected unmarshal error: %v", err)
+	}
+
+	if comp.GroupOrder != 3 {
+		t.Errorf("GroupOrder = %d, want 3", comp.GroupOrder)
+	}
+	if comp.Order != 0 {
+		t.Errorf("Order = %d, want 0", comp.Order)
+	}
+}
+
+func TestAPIUpdateComponentRequest_IncludesGroupOrder(t *testing.T) {
+	req := apiUpdateComponentRequest{
+		ID:         "1",
+		GroupOrder: ptr(int64(5)),
+	}
+
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("unexpected marshal error: %v", err)
+	}
+
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("unexpected unmarshal error: %v", err)
+	}
+
+	val, ok := raw["groupOrder"]
+	if !ok {
+		t.Fatal("groupOrder field missing from JSON")
+	}
+	if val != float64(5) {
+		t.Errorf("groupOrder = %v, want 5", val)
+	}
+}
+
+func TestAPIUpdateComponentRequest_OmitsNilGroupOrder(t *testing.T) {
+	req := apiUpdateComponentRequest{
+		ID: "1",
+	}
+
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("unexpected marshal error: %v", err)
+	}
+
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("unexpected unmarshal error: %v", err)
+	}
+
+	if _, ok := raw["groupOrder"]; ok {
+		t.Error("groupOrder should be omitted when nil")
+	}
+}
+
+func TestComponentAPIToModel_SetsGroupOrder(t *testing.T) {
+	api := apiComponent{
+		ID:         "1",
+		PageID:     "2",
+		Name:       "Hub UI",
+		Type:       "PAGE_COMPONENT_TYPE_MONITOR",
+		MonitorID:  "42",
+		Order:      0,
+		GroupID:    "10",
+		GroupOrder: 3,
+		CreatedAt:  "2026-03-23T00:00:00Z",
+		UpdatedAt:  "2026-03-23T00:00:00Z",
+	}
+
+	var data componentModel
+	componentAPIToModel(api, &data)
+
+	if data.GroupOrder.ValueInt64() != 3 {
+		t.Errorf("GroupOrder = %d, want 3", data.GroupOrder.ValueInt64())
+	}
+	if data.Order.ValueInt64() != 0 {
+		t.Errorf("Order = %d, want 0", data.Order.ValueInt64())
+	}
+}


### PR DESCRIPTION
# Description

The API exposes two ordering fields on page components:
- `order`: display order of the component's **group** on the status page
- `groupOrder`: display order of the component **within** its group

Only `order` was exposed in the provider. This adds `group_order` to the Terraform schema, create/update requests, and read responses so that component ordering within groups can be managed via Terraform.