### PR TITLE
feat: implement in-place Update for status pages

### DIFF
--- a/internal/statuspage/status_page_resource.go
+++ b/internal/statuspage/status_page_resource.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -63,71 +62,57 @@ func (r *statusPageResource) Configure(_ context.Context, req resource.Configure
 }
 
 func (r *statusPageResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
-	requiresReplace := []planmodifier.String{stringplanmodifier.RequiresReplace()}
-	requiresReplaceKeepState := []planmodifier.String{stringplanmodifier.RequiresReplace(), stringplanmodifier.UseStateForUnknown()}
+	keepState := []planmodifier.String{stringplanmodifier.UseStateForUnknown()}
 
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "Manages a status page. Any change to mutable attributes will destroy and recreate the resource.",
+		MarkdownDescription: "Manages a status page.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed:      true,
-				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+				PlanModifiers: keepState,
 			},
 			"title": schema.StringAttribute{
-				Required:      true,
-				Validators:    []validator.String{stringvalidator.LengthBetween(1, 256)},
-				PlanModifiers: requiresReplace,
+				Required:   true,
+				Validators: []validator.String{stringvalidator.LengthBetween(1, 256)},
 			},
 			"slug": schema.StringAttribute{
-				Required:      true,
-				Validators:    []validator.String{stringvalidator.LengthBetween(1, 256)},
-				PlanModifiers: requiresReplace,
+				Required:   true,
+				Validators: []validator.String{stringvalidator.LengthBetween(1, 256)},
 			},
 			"description": schema.StringAttribute{
-				Optional:      true,
-				Validators:    []validator.String{stringvalidator.LengthAtMost(1024)},
-				PlanModifiers: requiresReplace,
+				Optional:   true,
+				Validators: []validator.String{stringvalidator.LengthAtMost(1024)},
 			},
 			"homepage_url": schema.StringAttribute{
-				Optional:      true,
-				PlanModifiers: requiresReplace,
+				Optional: true,
 			},
 			"contact_url": schema.StringAttribute{
-				Optional:      true,
-				PlanModifiers: requiresReplace,
+				Optional: true,
 			},
 			"icon": schema.StringAttribute{
 				Optional:            true,
-				Computed:            true,
 				MarkdownDescription: "URL of the icon to display on the status page.",
-				PlanModifiers:       requiresReplaceKeepState,
 			},
 			"custom_domain": schema.StringAttribute{
 				Optional:            true,
-				Computed:            true,
 				MarkdownDescription: "Custom domain for the status page. DNS must point to OpenStatus before setting this.",
-				PlanModifiers:       requiresReplaceKeepState,
 			},
 			"access_type": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
 				MarkdownDescription: "Access type of the status page. One of: `public`, `password`, `email-domain`.",
 				Validators:          []validator.String{stringvalidator.OneOf("public", "password", "email-domain")},
-				PlanModifiers:       requiresReplaceKeepState,
+				PlanModifiers:       keepState,
 			},
 			"password": schema.StringAttribute{
 				Optional:            true,
-				Computed:            true,
 				Sensitive:           true,
 				MarkdownDescription: "Password to protect the status page. Required when `access_type` is `password`.",
-				PlanModifiers:       requiresReplaceKeepState,
 			},
 			"auth_email_domains": schema.ListAttribute{
-				Optional:            true,
-				Computed:            true,
-				ElementType:         types.StringType,
+				Optional:    true,
+				ElementType: types.StringType,
 				MarkdownDescription: "List of email domains allowed to access the page. Used when `access_type` is `email-domain`.",
-				PlanModifiers:       []planmodifier.List{listplanmodifier.RequiresReplace(), listplanmodifier.UseStateForUnknown()},
 			},
 			"published": schema.BoolAttribute{Computed: true},
 			"theme":     schema.StringAttribute{Computed: true},
@@ -148,6 +133,20 @@ type apiStatusPageCreateRequest struct {
 	Theme            string   `json:"theme,omitempty"`
 	AccessType       string   `json:"accessType,omitempty"`
 	Password         string   `json:"password,omitempty"`
+	AuthEmailDomains []string `json:"authEmailDomains,omitempty"`
+}
+
+type apiStatusPageUpdateRequest struct {
+	ID               string   `json:"id"`
+	Title            *string  `json:"title,omitempty"`
+	Slug             *string  `json:"slug,omitempty"`
+	Description      *string  `json:"description,omitempty"`
+	HomepageURL      *string  `json:"homepageUrl,omitempty"`
+	ContactURL       *string  `json:"contactUrl,omitempty"`
+	Icon             *string  `json:"icon,omitempty"`
+	CustomDomain     *string  `json:"customDomain,omitempty"`
+	AccessType       *string  `json:"accessType,omitempty"`
+	Password         *string  `json:"password,omitempty"`
 	AuthEmailDomains []string `json:"authEmailDomains,omitempty"`
 }
 
@@ -246,8 +245,61 @@ func (r *statusPageResource) Read(ctx context.Context, req resource.ReadRequest,
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
-func (r *statusPageResource) Update(_ context.Context, _ resource.UpdateRequest, _ *resource.UpdateResponse) {
-	// All mutable fields have RequiresReplace, so Update is never called.
+func (r *statusPageResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data statusPageModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Send all fields on every update. Null in plan means "clear the field" (empty string).
+	title := data.Title.ValueString()
+	slug := data.Slug.ValueString()
+	desc := data.Description.ValueString()
+	homepageURL := data.HomepageURL.ValueString()
+	contactURL := data.ContactURL.ValueString()
+	icon := data.Icon.ValueString()
+	customDomain := data.CustomDomain.ValueString()
+
+	updateReq := apiStatusPageUpdateRequest{
+		ID:           data.ID.ValueString(),
+		Title:        &title,
+		Slug:         &slug,
+		Description:  &desc,
+		HomepageURL:  &homepageURL,
+		ContactURL:   &contactURL,
+		Icon:         &icon,
+		CustomDomain: &customDomain,
+	}
+
+	// Password has a min_len=1 validation server-side, only send when set.
+	if !data.Password.IsNull() {
+		v := data.Password.ValueString()
+		updateReq.Password = &v
+	}
+
+	if !data.AccessType.IsNull() && !data.AccessType.IsUnknown() {
+		v := accessTypeToProto(data.AccessType.ValueString())
+		updateReq.AccessType = &v
+	}
+	if !data.AuthEmailDomains.IsNull() {
+		var domains []string
+		resp.Diagnostics.Append(data.AuthEmailDomains.ElementsAs(ctx, &domains, false)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		updateReq.AuthEmailDomains = domains
+	}
+
+	var apiResp apiStatusPageResponse
+	err := r.client.Do(ctx, "/openstatus.status_page.v1.StatusPageService/UpdateStatusPage", updateReq, &apiResp)
+	if err != nil {
+		resp.Diagnostics.AddError("Error updating status page", err.Error())
+		return
+	}
+
+	statusPageAPIToModel(ctx, apiResp.StatusPage, &data, &resp.Diagnostics)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
 func (r *statusPageResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
@@ -324,29 +376,21 @@ func statusPageAPIToModel(ctx context.Context, api apiStatusPage, data *statusPa
 	if api.ContactURL != "" || !data.ContactURL.IsNull() {
 		data.ContactURL = types.StringValue(api.ContactURL)
 	}
-	if api.Icon != "" {
+	if api.Icon != "" || !data.Icon.IsNull() {
 		data.Icon = types.StringValue(api.Icon)
-	} else if data.Icon.IsUnknown() {
-		data.Icon = types.StringNull()
 	}
-	if api.CustomDomain != "" {
+	if api.CustomDomain != "" || !data.CustomDomain.IsNull() {
 		data.CustomDomain = types.StringValue(api.CustomDomain)
-	} else if data.CustomDomain.IsUnknown() {
-		data.CustomDomain = types.StringNull()
 	}
 	data.Published = types.BoolValue(api.Published)
 	data.AccessType = types.StringValue(accessTypeFromProto(api.AccessType))
 	if api.Password != "" {
 		data.Password = types.StringValue(api.Password)
-	} else if data.Password.IsUnknown() {
-		data.Password = types.StringNull()
 	}
-	if len(api.AuthEmailDomains) > 0 {
+	if len(api.AuthEmailDomains) > 0 || !data.AuthEmailDomains.IsNull() {
 		list, listDiags := types.ListValueFrom(ctx, types.StringType, api.AuthEmailDomains)
 		diags.Append(listDiags...)
 		data.AuthEmailDomains = list
-	} else if data.AuthEmailDomains.IsUnknown() {
-		data.AuthEmailDomains = types.ListNull(types.StringType)
 	}
 	data.Theme = types.StringValue(themeFromProto(api.Theme))
 	data.CreatedAt = types.StringValue(api.CreatedAt)

--- a/internal/statuspage/status_page_resource.go
+++ b/internal/statuspage/status_page_resource.go
@@ -17,9 +17,10 @@ import (
 )
 
 var (
-	_ resource.Resource                = (*statusPageResource)(nil)
-	_ resource.ResourceWithConfigure   = (*statusPageResource)(nil)
-	_ resource.ResourceWithImportState = (*statusPageResource)(nil)
+	_ resource.Resource                   = (*statusPageResource)(nil)
+	_ resource.ResourceWithConfigure      = (*statusPageResource)(nil)
+	_ resource.ResourceWithImportState    = (*statusPageResource)(nil)
+	_ resource.ResourceWithValidateConfig = (*statusPageResource)(nil)
 )
 
 type providerConfig = client.ProviderConfig
@@ -119,6 +120,47 @@ func (r *statusPageResource) Schema(_ context.Context, _ resource.SchemaRequest,
 			"created_at":    schema.StringAttribute{Computed: true},
 			"updated_at":    schema.StringAttribute{Computed: true},
 		},
+	}
+}
+
+func (r *statusPageResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var data statusPageModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	accessType := data.AccessType.ValueString()
+	hasPassword := !data.Password.IsNull() && !data.Password.IsUnknown()
+	hasEmailDomains := !data.AuthEmailDomains.IsNull() && !data.AuthEmailDomains.IsUnknown()
+
+	if accessType == "password" && !hasPassword {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("password"),
+			"Missing required attribute",
+			"password is required when access_type is \"password\".",
+		)
+	}
+	if accessType == "email-domain" && !hasEmailDomains {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("auth_email_domains"),
+			"Missing required attribute",
+			"auth_email_domains is required when access_type is \"email-domain\".",
+		)
+	}
+	if hasPassword && accessType != "password" {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("password"),
+			"Invalid attribute combination",
+			"password can only be set when access_type is \"password\".",
+		)
+	}
+	if hasEmailDomains && accessType != "email-domain" {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("auth_email_domains"),
+			"Invalid attribute combination",
+			"auth_email_domains can only be set when access_type is \"email-domain\".",
+		)
 	}
 }
 

--- a/internal/statuspage/status_page_resource.go
+++ b/internal/statuspage/status_page_resource.go
@@ -137,17 +137,17 @@ type apiStatusPageCreateRequest struct {
 }
 
 type apiStatusPageUpdateRequest struct {
-	ID               string   `json:"id"`
-	Title            *string  `json:"title,omitempty"`
-	Slug             *string  `json:"slug,omitempty"`
-	Description      *string  `json:"description,omitempty"`
-	HomepageURL      *string  `json:"homepageUrl,omitempty"`
-	ContactURL       *string  `json:"contactUrl,omitempty"`
-	Icon             *string  `json:"icon,omitempty"`
-	CustomDomain     *string  `json:"customDomain,omitempty"`
-	AccessType       *string  `json:"accessType,omitempty"`
-	Password         *string  `json:"password,omitempty"`
-	AuthEmailDomains []string `json:"authEmailDomains,omitempty"`
+	ID               string    `json:"id"`
+	Title            *string   `json:"title,omitempty"`
+	Slug             *string   `json:"slug,omitempty"`
+	Description      *string   `json:"description,omitempty"`
+	HomepageURL      *string   `json:"homepageUrl,omitempty"`
+	ContactURL       *string   `json:"contactUrl,omitempty"`
+	Icon             *string   `json:"icon,omitempty"`
+	CustomDomain     *string   `json:"customDomain,omitempty"`
+	AccessType       *string   `json:"accessType,omitempty"`
+	Password         *string   `json:"password,omitempty"`
+	AuthEmailDomains *[]string `json:"authEmailDomains,omitempty"`
 }
 
 type apiStatusPageResponse struct {
@@ -273,7 +273,7 @@ func (r *statusPageResource) Update(ctx context.Context, req resource.UpdateRequ
 	}
 
 	// Password has a min_len=1 validation server-side, only send when set.
-	if !data.Password.IsNull() {
+	if !data.Password.IsNull() && !data.Password.IsUnknown() {
 		v := data.Password.ValueString()
 		updateReq.Password = &v
 	}
@@ -282,13 +282,13 @@ func (r *statusPageResource) Update(ctx context.Context, req resource.UpdateRequ
 		v := accessTypeToProto(data.AccessType.ValueString())
 		updateReq.AccessType = &v
 	}
-	if !data.AuthEmailDomains.IsNull() {
+	if !data.AuthEmailDomains.IsNull() && !data.AuthEmailDomains.IsUnknown() {
 		var domains []string
 		resp.Diagnostics.Append(data.AuthEmailDomains.ElementsAs(ctx, &domains, false)...)
 		if resp.Diagnostics.HasError() {
 			return
 		}
-		updateReq.AuthEmailDomains = domains
+		updateReq.AuthEmailDomains = &domains
 	}
 
 	var apiResp apiStatusPageResponse

--- a/internal/statuspage/status_page_resource_test.go
+++ b/internal/statuspage/status_page_resource_test.go
@@ -342,7 +342,7 @@ func TestAPIStatusPageUpdateRequest_AllFields(t *testing.T) {
 		CustomDomain:     &domain,
 		AccessType:       &access,
 		Password:         &pass,
-		AuthEmailDomains: []string{"acme.example.com"},
+		AuthEmailDomains: &[]string{"acme.example.com"},
 	}
 
 	data, err := json.Marshal(req)
@@ -363,6 +363,10 @@ func TestAPIStatusPageUpdateRequest_AllFields(t *testing.T) {
 	}
 	if raw["password"] != "secret" {
 		t.Errorf("password = %v, want secret", raw["password"])
+	}
+	domains, ok := raw["authEmailDomains"].([]interface{})
+	if !ok || len(domains) != 1 || domains[0] != "acme.example.com" {
+		t.Errorf("authEmailDomains = %v, want [acme.example.com]", raw["authEmailDomains"])
 	}
 }
 
@@ -415,5 +419,33 @@ func TestAPIStatusPageUpdateRequest_EmptyStringClearsField(t *testing.T) {
 	}
 	if _, ok := raw["homepageUrl"]; !ok {
 		t.Error("homepageUrl should be present with empty string to clear it")
+	}
+}
+
+func TestAPIStatusPageUpdateRequest_EmptySliceClearsAuthEmailDomains(t *testing.T) {
+	domains := []string{}
+	req := apiStatusPageUpdateRequest{
+		ID:               "42",
+		AuthEmailDomains: &domains,
+	}
+
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("unexpected marshal error: %v", err)
+	}
+
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("unexpected unmarshal error: %v", err)
+	}
+
+	// Empty slice via pointer should be present to clear the field server-side.
+	val, ok := raw["authEmailDomains"]
+	if !ok {
+		t.Fatal("authEmailDomains should be present with empty slice to clear it")
+	}
+	arr, ok := val.([]interface{})
+	if !ok || len(arr) != 0 {
+		t.Errorf("authEmailDomains = %v, want empty array", val)
 	}
 }

--- a/internal/statuspage/status_page_resource_test.go
+++ b/internal/statuspage/status_page_resource_test.go
@@ -317,3 +317,103 @@ func TestStatusPageAPIToModel_AuthEmailDomains(t *testing.T) {
 		t.Errorf("AccessType = %q, want %q", data.AccessType.ValueString(), "email-domain")
 	}
 }
+
+// --- Update request serialization ---
+
+func TestAPIStatusPageUpdateRequest_AllFields(t *testing.T) {
+	title := "Acme Corp Status"
+	slug := "acme-corp"
+	desc := "Updated description"
+	homepage := "https://acme.example.com"
+	contact := "mailto:support@acme.example.com"
+	icon := "https://acme.example.com/icon.png"
+	domain := "status.acme.example.com"
+	access := "PAGE_ACCESS_TYPE_PASSWORD_PROTECTED"
+	pass := "secret"
+
+	req := apiStatusPageUpdateRequest{
+		ID:               "42",
+		Title:            &title,
+		Slug:             &slug,
+		Description:      &desc,
+		HomepageURL:      &homepage,
+		ContactURL:       &contact,
+		Icon:             &icon,
+		CustomDomain:     &domain,
+		AccessType:       &access,
+		Password:         &pass,
+		AuthEmailDomains: []string{"acme.example.com"},
+	}
+
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("unexpected marshal error: %v", err)
+	}
+
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("unexpected unmarshal error: %v", err)
+	}
+
+	if raw["id"] != "42" {
+		t.Errorf("id = %v, want 42", raw["id"])
+	}
+	if raw["title"] != "Acme Corp Status" {
+		t.Errorf("title = %v, want Acme Corp Status", raw["title"])
+	}
+	if raw["password"] != "secret" {
+		t.Errorf("password = %v, want secret", raw["password"])
+	}
+}
+
+func TestAPIStatusPageUpdateRequest_OmitsNilFields(t *testing.T) {
+	title := "Acme Corp Status"
+	req := apiStatusPageUpdateRequest{
+		ID:    "42",
+		Title: &title,
+	}
+
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("unexpected marshal error: %v", err)
+	}
+
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("unexpected unmarshal error: %v", err)
+	}
+
+	omitted := []string{"slug", "description", "homepageUrl", "contactUrl", "icon", "customDomain", "accessType", "password", "authEmailDomains"}
+	for _, field := range omitted {
+		if _, ok := raw[field]; ok {
+			t.Errorf("field %q should be omitted when nil", field)
+		}
+	}
+}
+
+func TestAPIStatusPageUpdateRequest_EmptyStringClearsField(t *testing.T) {
+	empty := ""
+	req := apiStatusPageUpdateRequest{
+		ID:          "42",
+		ContactURL:  &empty,
+		HomepageURL: &empty,
+	}
+
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("unexpected marshal error: %v", err)
+	}
+
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("unexpected unmarshal error: %v", err)
+	}
+
+	// Empty strings should be present (not omitted) to clear the field server-side.
+	if _, ok := raw["contactUrl"]; !ok {
+		t.Error("contactUrl should be present with empty string to clear it")
+	}
+	if _, ok := raw["homepageUrl"]; !ok {
+		t.Error("homepageUrl should be present with empty string to clear it")
+	}
+}


### PR DESCRIPTION
## Summary

- Implement `Update` method using the `UpdateStatusPage` RPC, so changes no longer force destroy/recreate
- Remove `RequiresReplace` from all mutable attributes
- Remove unnecessary `Computed` on `icon`, `custom_domain`, `password`, `auth_email_domains` (they are purely user-driven)
- Add `apiStatusPageUpdateRequest` struct with pointer fields to support partial updates
- Clean up unused `listplanmodifier` import

Follow-up to #12 — now that the RPC API supports `UpdateStatusPage`, in-place updates are possible.