### PR TITLE
feat(monitor): validate regions against allowlist at plan time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v0.2.1
+
+### Changed
+
+- **`regions` is now validated at plan time** on `openstatus_http_monitor`, `openstatus_tcp_monitor`, and `openstatus_dns_monitor`. Configs that reference an unknown region (typo, copy-paste from another provider, a region the OpenStatus API doesn't yet expose) now fail at `terraform plan` instead of mid-apply. The accepted set is unchanged — see the resource docs for the full list. If you need a region that isn't listed, open an issue; the fix is a one-line addition to `regionToAPI` in the provider.
+- **`regions` attribute now has a consistent description** ("Regions to monitor from.") on the TCP and DNS monitor resources, matching the HTTP monitor and improving the generated docs.
+
+### Fixed
+
+- **Generated provider docs are now deterministic** for enum-shaped attributes (`periodicity`, `regions`, `method`, comparator fields). Previously the helper that derived the allowed-values list iterated a Go map directly, which produced nondeterministic ordering between regenerations.
+
 ## v0.2.0
 
 ### Breaking changes

--- a/docs/resources/dns_monitor.md
+++ b/docs/resources/dns_monitor.md
@@ -49,7 +49,7 @@ resource "openstatus_dns_monitor" "main" {
 - `open_telemetry` (Block, Optional) OpenTelemetry exporter configuration. (see [below for nested schema](#nestedblock--open_telemetry))
 - `public` (Boolean)
 - `record_assertions` (Block List) (see [below for nested schema](#nestedblock--record_assertions))
-- `regions` (Set of String)
+- `regions` (Set of String) Regions to monitor from.
 - `retry` (Number)
 - `timeout` (Number)
 

--- a/docs/resources/tcp_monitor.md
+++ b/docs/resources/tcp_monitor.md
@@ -43,7 +43,7 @@ resource "openstatus_tcp_monitor" "db" {
 - `description` (String)
 - `open_telemetry` (Block, Optional) OpenTelemetry exporter configuration. (see [below for nested schema](#nestedblock--open_telemetry))
 - `public` (Boolean)
-- `regions` (Set of String)
+- `regions` (Set of String) Regions to monitor from.
 - `retry` (Number)
 - `timeout` (Number)
 

--- a/internal/monitor/common.go
+++ b/internal/monitor/common.go
@@ -2,6 +2,7 @@ package monitor
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 )
 
@@ -19,33 +20,33 @@ var periodicityFromAPI = reverseMap(periodicityToAPI)
 var PeriodicityValues = keys(periodicityToAPI)
 
 var regionToAPI = map[string]string{
-	"fly-ams":               "REGION_FLY_AMS",
-	"fly-arn":               "REGION_FLY_ARN",
-	"fly-bom":               "REGION_FLY_BOM",
-	"fly-cdg":               "REGION_FLY_CDG",
-	"fly-dfw":               "REGION_FLY_DFW",
-	"fly-ewr":               "REGION_FLY_EWR",
-	"fly-fra":               "REGION_FLY_FRA",
-	"fly-gru":               "REGION_FLY_GRU",
-	"fly-iad":               "REGION_FLY_IAD",
-	"fly-jnb":               "REGION_FLY_JNB",
-	"fly-lax":               "REGION_FLY_LAX",
-	"fly-lhr":               "REGION_FLY_LHR",
-	"fly-nrt":               "REGION_FLY_NRT",
-	"fly-ord":               "REGION_FLY_ORD",
-	"fly-sjc":               "REGION_FLY_SJC",
-	"fly-sin":               "REGION_FLY_SIN",
-	"fly-syd":               "REGION_FLY_SYD",
-	"fly-yyz":               "REGION_FLY_YYZ",
-	"koyeb-fra":             "REGION_KOYEB_FRA",
-	"koyeb-par":             "REGION_KOYEB_PAR",
-	"koyeb-sfo":             "REGION_KOYEB_SFO",
-	"koyeb-sin":             "REGION_KOYEB_SIN",
-	"koyeb-tyo":             "REGION_KOYEB_TYO",
-	"koyeb-was":             "REGION_KOYEB_WAS",
-	"railway-us-west2":      "REGION_RAILWAY_US_WEST2",
-	"railway-us-east4":      "REGION_RAILWAY_US_EAST4",
-	"railway-europe-west4":  "REGION_RAILWAY_EUROPE_WEST4",
+	"fly-ams":                 "REGION_FLY_AMS",
+	"fly-arn":                 "REGION_FLY_ARN",
+	"fly-bom":                 "REGION_FLY_BOM",
+	"fly-cdg":                 "REGION_FLY_CDG",
+	"fly-dfw":                 "REGION_FLY_DFW",
+	"fly-ewr":                 "REGION_FLY_EWR",
+	"fly-fra":                 "REGION_FLY_FRA",
+	"fly-gru":                 "REGION_FLY_GRU",
+	"fly-iad":                 "REGION_FLY_IAD",
+	"fly-jnb":                 "REGION_FLY_JNB",
+	"fly-lax":                 "REGION_FLY_LAX",
+	"fly-lhr":                 "REGION_FLY_LHR",
+	"fly-nrt":                 "REGION_FLY_NRT",
+	"fly-ord":                 "REGION_FLY_ORD",
+	"fly-sjc":                 "REGION_FLY_SJC",
+	"fly-sin":                 "REGION_FLY_SIN",
+	"fly-syd":                 "REGION_FLY_SYD",
+	"fly-yyz":                 "REGION_FLY_YYZ",
+	"koyeb-fra":               "REGION_KOYEB_FRA",
+	"koyeb-par":               "REGION_KOYEB_PAR",
+	"koyeb-sfo":               "REGION_KOYEB_SFO",
+	"koyeb-sin":               "REGION_KOYEB_SIN",
+	"koyeb-tyo":               "REGION_KOYEB_TYO",
+	"koyeb-was":               "REGION_KOYEB_WAS",
+	"railway-us-west2":        "REGION_RAILWAY_US_WEST2",
+	"railway-us-east4":        "REGION_RAILWAY_US_EAST4",
+	"railway-europe-west4":    "REGION_RAILWAY_EUROPE_WEST4",
 	"railway-asia-southeast1": "REGION_RAILWAY_ASIA_SOUTHEAST1",
 }
 
@@ -223,5 +224,6 @@ func keys(m map[string]string) []string {
 	for k := range m {
 		out = append(out, k)
 	}
+	sort.Strings(out)
 	return out
 }

--- a/internal/monitor/common_test.go
+++ b/internal/monitor/common_test.go
@@ -1,6 +1,8 @@
 package monitor
 
 import (
+	"sort"
+	"strings"
 	"testing"
 )
 
@@ -37,6 +39,22 @@ func TestMapPeriodicityFromAPI(t *testing.T) {
 	result := MapPeriodicityFromAPI("PERIODICITY_30S")
 	if result != "30s" {
 		t.Errorf("MapPeriodicityFromAPI(PERIODICITY_30S) = %q, want 30s", result)
+	}
+}
+
+func TestRegionValuesSorted(t *testing.T) {
+	if !sort.StringsAreSorted(RegionValues) {
+		t.Errorf("RegionValues must be sorted for deterministic docs; got %v", RegionValues)
+	}
+}
+
+func TestMapRegionsToAPI_InvalidReturnsError(t *testing.T) {
+	_, err := MapRegionsToAPI([]string{"railway-europe-ewlrljw"})
+	if err == nil {
+		t.Fatal("expected error for unknown region, got nil")
+	}
+	if !strings.Contains(err.Error(), `unknown region: "railway-europe-ewlrljw"`) {
+		t.Errorf("unexpected error message: %v", err)
 	}
 }
 

--- a/internal/monitor/dns_monitor_resource.go
+++ b/internal/monitor/dns_monitor_resource.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -121,8 +122,12 @@ func (r *dnsMonitorResource) Schema(_ context.Context, _ resource.SchemaRequest,
 				Validators: []validator.String{stringvalidator.LengthAtMost(1024)},
 			},
 			"regions": schema.SetAttribute{
-				Optional:    true,
-				ElementType: types.StringType,
+				Optional:            true,
+				ElementType:         types.StringType,
+				MarkdownDescription: "Regions to monitor from.",
+				Validators: []validator.Set{
+					setvalidator.ValueStringsAre(stringvalidator.OneOf(RegionValues...)),
+				},
 			},
 			"status": schema.StringAttribute{
 				Computed:      true,

--- a/internal/monitor/http_monitor_resource.go
+++ b/internal/monitor/http_monitor_resource.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -174,6 +175,9 @@ func (r *httpMonitorResource) Schema(_ context.Context, _ resource.SchemaRequest
 				Optional:            true,
 				ElementType:         types.StringType,
 				MarkdownDescription: "Regions to monitor from.",
+				Validators: []validator.Set{
+					setvalidator.ValueStringsAre(stringvalidator.OneOf(RegionValues...)),
+				},
 			},
 			"status": schema.StringAttribute{
 				Computed:            true,

--- a/internal/monitor/tcp_monitor_resource.go
+++ b/internal/monitor/tcp_monitor_resource.go
@@ -6,6 +6,7 @@ import (
 	"terraform-provider-openstatus/internal/client"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -112,8 +113,12 @@ func (r *tcpMonitorResource) Schema(_ context.Context, _ resource.SchemaRequest,
 				Validators: []validator.String{stringvalidator.LengthAtMost(1024)},
 			},
 			"regions": schema.SetAttribute{
-				Optional:    true,
-				ElementType: types.StringType,
+				Optional:            true,
+				ElementType:         types.StringType,
+				MarkdownDescription: "Regions to monitor from.",
+				Validators: []validator.Set{
+					setvalidator.ValueStringsAre(stringvalidator.OneOf(RegionValues...)),
+				},
 			},
 			"status": schema.StringAttribute{
 				Computed:      true,

--- a/justfile
+++ b/justfile
@@ -31,7 +31,7 @@ dev: build
 # `just dev` for local iteration.
 install: build
     #!/usr/bin/env sh
-    dir=~/.terraform.d/plugins/registry.terraform.io/openstatusHQ/openstatus/0.2.0/$(go env GOOS)_$(go env GOARCH)
+    dir=~/.terraform.d/plugins/registry.terraform.io/openstatusHQ/openstatus/0.2.1/$(go env GOOS)_$(go env GOARCH)
     mkdir -p "$dir"
     cp terraform-provider-openstatus "$dir"/
 


### PR DESCRIPTION
## Summary

Adds plan-time validation of the `regions` attribute on the three monitor resources (`openstatus_http_monitor`, `openstatus_tcp_monitor`, `openstatus_dns_monitor`). Configs with an unknown region now fail at `terraform plan` instead of mid-apply. Also makes `keys()` in `internal/monitor/common.go` return sorted output so generated docs and validator error messages are deterministic across regenerations.

Released as `v0.2.1` (patch — strictly stricter validation, no removal of working behavior).

## Phase 3 verification (against `api.openstatus.dev`)

- **Negative case** — `regions = ["fly-iad", "railway-europe-ewlrljw"]` rejected at `terraform plan` time with the validator error; no API RPC issued.
- **Positive case** — `regions = ["fly-iad", "fly-ams"]` applied cleanly; re-plan shows "No changes."

## Design decisions

| # | Decision | Rationale |
|---|---|---|
| D1 | HCL user-facing slugs stay `fly-iad` / `koyeb-fra` / `railway-us-east4` style | Matches existing convention; users don't need to learn platform-internal zone codes |
| D2 | Two substantive commits + one release-prep commit, single PR | Repo's `v0.2.0` precedent: one concern per commit |
| D3 | Keep `MapRegionsToAPI` runtime error as defense-in-depth | Trivial cost; guards against state drift and future refactoring |
| D4 | Sort all six value lists via `keys()` itself, not just `RegionValues` | One-line change that eliminates a known source of future doc churn across the whole monitor surface |
| D5 | Two new tests in `common_test.go` (`TestRegionValuesSorted`, `TestMapRegionsToAPI_InvalidReturnsError`) | One test, one intent — easy to bisect later |
| D6 | Drop `!` from commit titles | Configs that previously succeeded keep succeeding; only previously-broken configs now fail earlier |
| D7 | Cut as `v0.2.1` (patch bump) | Strictly stricter validation, no removal of working behavior |
| D8 | Phase 3 manual verification against prod `api.openstatus.dev` | Production wire format is the only thing worth proving end-to-end |
| D9 | Commit messages are subject-only | Matches the five most recent commits in this repo |
| D10 | Commit 1 prefix is `feat(monitor):`, not `fix(monitor):` | Precedent: `feat(notification)!: require name …` was the analog tightening (Optional → Required) |
| D11 | No case-sensitivity test; `TF_LOG=DEBUG` grep is the concrete "no API call" check | Case sensitivity is a framework property, not our code |
| D12 | PR workflow, not direct push | A `v0.2.x` cut benefits from a reviewable surface |
| D13 | Decisions table replicated in PR description | The local `plan-bug.md` working artifact is gitignored |
| D14 | Phase 0.7 doc baseline is a hard stop, not a soft stash | A pre-existing doc drift would silently contaminate commit 2 |

## Commits

1. `feat(monitor): validate regions against allowlist at plan time` — validator, sorted `keys()`, tcp/dns description fix, two new tests.
2. `chore(docs): regenerate after region validator` — `tcp_monitor.md` / `dns_monitor.md` pick up the new description line.
3. `chore: prepare v0.2.1 release` — CHANGELOG entry, `justfile` install path bump.

Reviewers: commit 2 is mechanical doc regen.

## Test plan

- [ ] `go test ./...` passes (CI runs this automatically).
- [ ] `just docs` is idempotent after merge.