### PR TITLE
fix(monitor,notification): plan/apply consistency for headers and ntf…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.2.2
+
+### Fixed
+
+- **`openstatus_http_monitor` apply no longer fails with `"block count changed from 0 to 1"`** ([#19](https://github.com/openstatusHQ/terraform-provider-openstatus/issues/19)). The OpenStatus API echoes a placeholder empty header (`headers: [{}]`) when no headers are configured; the provider now drops empty entries before writing state, restoring plan↔apply consistency. Real headers (any non-empty key or value) are unaffected, and drift detection still works when a header is added or removed out-of-band via the dashboard.
+- **`openstatus_notification` ntfy block no longer fails with `"Received null value, however the target type cannot handle null values"`** when `server_url` or `token` is omitted. Both are documented as `Optional` in the schema; the extract path was decoding them into plain `string`, which the framework rejects for null inputs. They now decode through `types.String` and are only sent to the API when non-empty.
+- **`openstatus_notification` ntfy update no longer fails with `"inconsistent values for sensitive attribute"`** on `.ntfy[0].token`. The OpenStatus API does not echo back ntfy.token in its response (security default for sensitive fields); the read-back mapper now preserves the planned/state token when the API omits it, so the post-apply state matches what Terraform planned. If the API ever does return a token, that value still takes priority.
+
 ## v0.2.1
 
 ### Changed

--- a/internal/monitor/http_monitor_resource.go
+++ b/internal/monitor/http_monitor_resource.go
@@ -565,20 +565,23 @@ func httpAPIToModel(ctx context.Context, api httpMonitorAPIObject, data *httpMon
 		data.Regions = types.SetNull(types.StringType)
 	}
 
-	if len(api.Headers) > 0 {
-		headerObjs := make([]attr.Value, 0, len(api.Headers))
-		for _, h := range api.Headers {
-			obj, d := types.ObjectValue(headerObjTypes, map[string]attr.Value{
-				"key":   types.StringValue(h.Key),
-				"value": types.StringValue(h.Value),
-			})
-			diags.Append(d...)
-			headerObjs = append(headerObjs, obj)
+	// API returns `headers: [{}]` as a placeholder when no headers are
+	// configured. Drop empty entries so block count matches the plan (#19).
+	headerObjs := make([]attr.Value, 0, len(api.Headers))
+	for _, h := range api.Headers {
+		if h.Key == "" && h.Value == "" {
+			continue
 		}
-		headerList, d := types.ListValue(types.ObjectType{AttrTypes: headerObjTypes}, headerObjs)
+		obj, d := types.ObjectValue(headerObjTypes, map[string]attr.Value{
+			"key":   types.StringValue(h.Key),
+			"value": types.StringValue(h.Value),
+		})
 		diags.Append(d...)
-		data.Headers = headerList
+		headerObjs = append(headerObjs, obj)
 	}
+	headerList, d := types.ListValue(types.ObjectType{AttrTypes: headerObjTypes}, headerObjs)
+	diags.Append(d...)
+	data.Headers = headerList
 
 	if len(api.StatusCodeAssertions) > 0 {
 		objs := make([]attr.Value, 0, len(api.StatusCodeAssertions))

--- a/internal/monitor/http_monitor_resource_test.go
+++ b/internal/monitor/http_monitor_resource_test.go
@@ -1,8 +1,11 @@
 package monitor
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 func TestHTTPMonitorAPIObject_BoolFalseNotOmitted(t *testing.T) {
@@ -59,6 +62,122 @@ func TestHTTPMonitorAPIObject_ClearableScalarsNotOmitted(t *testing.T) {
 		if _, ok := raw[field]; !ok {
 			t.Errorf("field %q omitted from JSON when zero — omitempty must be removed", field)
 		}
+	}
+}
+
+func TestHTTPAPIToModel_DropsEmptyPlaceholderHeader(t *testing.T) {
+	api := httpMonitorAPIObject{
+		Headers: []apiHeader{{Key: "", Value: ""}},
+	}
+	var data httpMonitorModel
+	data.Headers = types.ListNull(types.ObjectType{AttrTypes: headerObjTypes})
+
+	diags := httpAPIToModel(context.Background(), api, &data)
+	if diags.HasError() {
+		t.Fatalf("unexpected diags: %v", diags)
+	}
+	if data.Headers.IsNull() {
+		t.Fatal("Headers is null, want empty list")
+	}
+	if got := len(data.Headers.Elements()); got != 0 {
+		t.Errorf("Headers length = %d, want 0", got)
+	}
+}
+
+func TestHTTPAPIToModel_KeepsRealHeaders(t *testing.T) {
+	api := httpMonitorAPIObject{
+		Headers: []apiHeader{{Key: "X-Api-Key", Value: "secret"}},
+	}
+	var data httpMonitorModel
+
+	diags := httpAPIToModel(context.Background(), api, &data)
+	if diags.HasError() {
+		t.Fatalf("unexpected diags: %v", diags)
+	}
+	if data.Headers.IsNull() {
+		t.Fatal("Headers is null, want one-element list")
+	}
+	elems := data.Headers.Elements()
+	if len(elems) != 1 {
+		t.Fatalf("Headers length = %d, want 1", len(elems))
+	}
+	obj, ok := elems[0].(types.Object)
+	if !ok {
+		t.Fatalf("element is %T, want types.Object", elems[0])
+	}
+	attrs := obj.Attributes()
+	key, ok := attrs["key"].(types.String)
+	if !ok {
+		t.Fatalf("key is %T, want types.String", attrs["key"])
+	}
+	if got := key.ValueString(); got != "X-Api-Key" {
+		t.Errorf("key = %q, want %q", got, "X-Api-Key")
+	}
+	value, ok := attrs["value"].(types.String)
+	if !ok {
+		t.Fatalf("value is %T, want types.String", attrs["value"])
+	}
+	if got := value.ValueString(); got != "secret" {
+		t.Errorf("value = %q, want %q", got, "secret")
+	}
+}
+
+func TestHTTPAPIToModel_KeepsRealHeadersAlongsidePlaceholder(t *testing.T) {
+	api := httpMonitorAPIObject{
+		Headers: []apiHeader{
+			{Key: "", Value: ""},
+			{Key: "X", Value: "Y"},
+			{Key: "", Value: ""},
+		},
+	}
+	var data httpMonitorModel
+
+	diags := httpAPIToModel(context.Background(), api, &data)
+	if diags.HasError() {
+		t.Fatalf("unexpected diags: %v", diags)
+	}
+	elems := data.Headers.Elements()
+	if len(elems) != 1 {
+		t.Fatalf("Headers length = %d, want 1 (placeholders dropped)", len(elems))
+	}
+	obj, ok := elems[0].(types.Object)
+	if !ok {
+		t.Fatalf("element is %T, want types.Object", elems[0])
+	}
+	attrs := obj.Attributes()
+	key, ok := attrs["key"].(types.String)
+	if !ok {
+		t.Fatalf("key is %T, want types.String", attrs["key"])
+	}
+	if got := key.ValueString(); got != "X" {
+		t.Errorf("key = %q, want %q", got, "X")
+	}
+	value, ok := attrs["value"].(types.String)
+	if !ok {
+		t.Fatalf("value is %T, want types.String", attrs["value"])
+	}
+	if got := value.ValueString(); got != "Y" {
+		t.Errorf("value = %q, want %q", got, "Y")
+	}
+}
+
+func TestHTTPAPIToModel_HeaderListShapeMatchesGetForAbsentBlock(t *testing.T) {
+	// Sanity: when the API returns nothing and state had no headers, the
+	// mapper should produce an empty (non-null) list — matching the shape
+	// Get() produces for an absent ListNestedBlock. Guards #19 from
+	// regressing if someone "optimizes" the filter back to a null branch.
+	api := httpMonitorAPIObject{Headers: nil}
+	var data httpMonitorModel
+
+	diags := httpAPIToModel(context.Background(), api, &data)
+	if diags.HasError() {
+		t.Fatalf("unexpected diags: %v", diags)
+	}
+	if data.Headers.IsNull() {
+		t.Fatal("Headers is null, want empty list to match plan shape")
+	}
+	if got := len(data.Headers.Elements()); got != 0 {
+		t.Errorf("Headers length = %d, want 0", got)
 	}
 }
 

--- a/internal/notification/notification_resource.go
+++ b/internal/notification/notification_resource.go
@@ -541,10 +541,14 @@ func extractWebhookEndpointBlock(ctx context.Context, list types.List, diags *di
 }
 
 func extractNtfyBlock(ctx context.Context, list types.List, diags *diag.Diagnostics) (map[string]interface{}, diag.Diagnostics) {
+	// Optional fields must use types.String so null values (i.e. attribute
+	// omitted in HCL) round-trip without conversion errors. Plain `string`
+	// fails ElementsAs with "Received null value, however the target type
+	// cannot handle null values".
 	var items []struct {
-		Topic     string `tfsdk:"topic"`
-		ServerURL string `tfsdk:"server_url"`
-		Token     string `tfsdk:"token"`
+		Topic     string       `tfsdk:"topic"`
+		ServerURL types.String `tfsdk:"server_url"`
+		Token     types.String `tfsdk:"token"`
 	}
 	diags.Append(list.ElementsAs(ctx, &items, false)...)
 	if len(items) == 0 {
@@ -552,11 +556,11 @@ func extractNtfyBlock(ctx context.Context, list types.List, diags *diag.Diagnost
 		return nil, *diags
 	}
 	result := map[string]interface{}{"topic": items[0].Topic}
-	if items[0].ServerURL != "" {
-		result["serverUrl"] = items[0].ServerURL
+	if v := items[0].ServerURL.ValueString(); v != "" {
+		result["serverUrl"] = v
 	}
-	if items[0].Token != "" {
-		result["token"] = items[0].Token
+	if v := items[0].Token.ValueString(); v != "" {
+		result["token"] = v
 	}
 	return result, *diags
 }
@@ -616,6 +620,10 @@ func notificationAPIToModel(ctx context.Context, api apiNotification, data *noti
 	grafanaOncallType := map[string]attr.Type{"webhook_url": types.StringType}
 	ntfyType := map[string]attr.Type{"topic": types.StringType, "server_url": types.StringType, "token": types.StringType}
 	msTeamsType := map[string]attr.Type{"webhook_url": types.StringType}
+
+	// Capture sensitive values that the API does not echo back before the
+	// per-provider lists are reset below. See ntfy.token note in the switch.
+	plannedNtfyToken := existingNtfyStringField(data.Ntfy, "token")
 
 	data.Discord = nullList(discordType)
 	data.Email = nullList(emailType)
@@ -709,10 +717,22 @@ func notificationAPIToModel(ctx context.Context, api apiNotification, data *noti
 			"webhook_url": types.StringValue(strFromData(apiData, "webhookUrl")),
 		}, &diags)
 	case "ntfy":
+		// The API does not echo back ntfy.token (Sensitive). If the response
+		// omits it, fall back to plannedNtfyToken (captured above before the
+		// per-provider reset) — otherwise Terraform reports "inconsistent
+		// values for sensitive attribute". Preserve the planned shape
+		// (null vs value): if the user omitted token in HCL the planned
+		// value is null, so post-apply state must be null too.
+		var token types.String
+		if v := strFromData(apiData, "token"); v != "" {
+			token = types.StringValue(v)
+		} else {
+			token = plannedNtfyToken
+		}
 		data.Ntfy = buildSingleObjList(ctx, ntfyType, map[string]attr.Value{
 			"topic":      types.StringValue(strFromData(apiData, "topic")),
 			"server_url": types.StringValue(strFromData(apiData, "serverUrl")),
-			"token":      types.StringValue(strFromData(apiData, "token")),
+			"token":      token,
 		}, &diags)
 	case "ms_teams":
 		data.MSTeams = buildSingleObjList(ctx, msTeamsType, map[string]attr.Value{
@@ -729,6 +749,35 @@ func buildSingleObjList(_ context.Context, attrTypes map[string]attr.Type, vals 
 	list, d := types.ListValue(types.ObjectType{AttrTypes: attrTypes}, []attr.Value{obj})
 	diags.Append(d...)
 	return list
+}
+
+// existingNtfyStringField returns the planned/state value of the given
+// tfsdk string attribute on the single-element ntfy list. Returns
+// types.StringNull() if the list is null/empty/unknown or the attribute
+// isn't a string. Preserves the *shape* (null vs value vs empty string)
+// — critical for Sensitive attributes, where Terraform compares plan and
+// post-apply state byte-for-byte.
+func existingNtfyStringField(list types.List, attr string) types.String {
+	if list.IsNull() || list.IsUnknown() {
+		return types.StringNull()
+	}
+	elems := list.Elements()
+	if len(elems) == 0 {
+		return types.StringNull()
+	}
+	obj, ok := elems[0].(types.Object)
+	if !ok {
+		return types.StringNull()
+	}
+	v, ok := obj.Attributes()[attr]
+	if !ok {
+		return types.StringNull()
+	}
+	s, ok := v.(types.String)
+	if !ok {
+		return types.StringNull()
+	}
+	return s
 }
 
 func strFromData(data map[string]interface{}, key string) string {

--- a/internal/notification/notification_resource_test.go
+++ b/internal/notification/notification_resource_test.go
@@ -245,6 +245,209 @@ func TestNotificationAPIToModel_UnknownOpsgenieRegionWarns(t *testing.T) {
 	}
 }
 
+func TestExtractProviderData_NtfyOmitsOptionalFields(t *testing.T) {
+	// Optional ntfy attributes (server_url, token) must round-trip when
+	// omitted in HCL. Before the fix, ElementsAs into a plain `string`
+	// failed with "Received null value, however the target type cannot
+	// handle null values" → terraform apply aborted with a Value
+	// Conversion Error.
+	attrTypes := map[string]attr.Type{
+		"topic":      types.StringType,
+		"server_url": types.StringType,
+		"token":      types.StringType,
+	}
+	obj, _ := types.ObjectValue(attrTypes, map[string]attr.Value{
+		"topic":      types.StringValue("alerts"),
+		"server_url": types.StringNull(),
+		"token":      types.StringNull(),
+	})
+	list, _ := types.ListValue(types.ObjectType{AttrTypes: attrTypes}, []attr.Value{obj})
+
+	model := notificationModel{
+		ProviderType: types.StringValue("ntfy"),
+		Ntfy:         list,
+	}
+	got, diags := extractProviderData(context.Background(), model)
+	if diags.HasError() {
+		t.Fatalf("unexpected diags: %v", diags)
+	}
+	inner, ok := got["ntfy"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("ntfy payload type = %T, want map", got["ntfy"])
+	}
+	if inner["topic"] != "alerts" {
+		t.Errorf("topic = %v, want alerts", inner["topic"])
+	}
+	if _, ok := inner["serverUrl"]; ok {
+		t.Errorf("serverUrl was sent despite null source; got=%v", inner["serverUrl"])
+	}
+	if _, ok := inner["token"]; ok {
+		t.Errorf("token was sent despite null source; got=%v", inner["token"])
+	}
+}
+
+func TestExtractProviderData_NtfyKeepsOptionalFields(t *testing.T) {
+	attrTypes := map[string]attr.Type{
+		"topic":      types.StringType,
+		"server_url": types.StringType,
+		"token":      types.StringType,
+	}
+	obj, _ := types.ObjectValue(attrTypes, map[string]attr.Value{
+		"topic":      types.StringValue("alerts"),
+		"server_url": types.StringValue("https://ntfy.example.com"),
+		"token":      types.StringValue("tk_123"),
+	})
+	list, _ := types.ListValue(types.ObjectType{AttrTypes: attrTypes}, []attr.Value{obj})
+
+	model := notificationModel{
+		ProviderType: types.StringValue("ntfy"),
+		Ntfy:         list,
+	}
+	got, diags := extractProviderData(context.Background(), model)
+	if diags.HasError() {
+		t.Fatalf("unexpected diags: %v", diags)
+	}
+	inner, ok := got["ntfy"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("ntfy payload type = %T, want map", got["ntfy"])
+	}
+	if inner["serverUrl"] != "https://ntfy.example.com" {
+		t.Errorf("serverUrl = %v, want https://ntfy.example.com", inner["serverUrl"])
+	}
+	if inner["token"] != "tk_123" {
+		t.Errorf("token = %v, want tk_123", inner["token"])
+	}
+}
+
+func TestNotificationAPIToModel_NtfyKeepsNullTokenWhenOmittedFromHCL(t *testing.T) {
+	// User's HCL has no `token = ...` line. Plan token is null. API doesn't
+	// echo token. Post-apply state token MUST be null (not "") — otherwise
+	// Terraform aborts with "inconsistent values for sensitive attribute".
+	attrTypes := map[string]attr.Type{
+		"topic":      types.StringType,
+		"server_url": types.StringType,
+		"token":      types.StringType,
+	}
+	plannedObj, _ := types.ObjectValue(attrTypes, map[string]attr.Value{
+		"topic":      types.StringValue("openstatus"),
+		"server_url": types.StringValue("https://ntfy.sh"),
+		"token":      types.StringNull(),
+	})
+	plannedList, _ := types.ListValue(types.ObjectType{AttrTypes: attrTypes}, []attr.Value{plannedObj})
+
+	api := apiNotification{
+		ID:       "1128",
+		Provider: "NOTIFICATION_PROVIDER_NTFY",
+		Data: map[string]interface{}{
+			"ntfy": map[string]interface{}{
+				"topic":     "openstatus",
+				"serverUrl": "https://ntfy.sh",
+			},
+		},
+	}
+	data := notificationModel{Ntfy: plannedList}
+
+	diags := notificationAPIToModel(context.Background(), api, &data)
+	if diags.HasError() {
+		t.Fatalf("unexpected diags: %v", diags)
+	}
+	obj, ok := data.Ntfy.Elements()[0].(types.Object)
+	if !ok {
+		t.Fatalf("element is %T, want types.Object", data.Ntfy.Elements()[0])
+	}
+	tok, ok := obj.Attributes()["token"].(types.String)
+	if !ok {
+		t.Fatalf("token is %T, want types.String", obj.Attributes()["token"])
+	}
+	if !tok.IsNull() {
+		t.Errorf("token = %q (IsNull=false), want null to match planned null shape", tok.ValueString())
+	}
+}
+
+func TestNotificationAPIToModel_NtfyPreservesTokenWhenAPIStripsIt(t *testing.T) {
+	// The OpenStatus API does not echo back ntfy.token (Sensitive). On
+	// Update, the mapper must preserve the value already in data (loaded
+	// from Plan) so the post-apply state matches what Terraform planned —
+	// otherwise apply fails with "inconsistent values for sensitive
+	// attribute".
+	attrTypes := map[string]attr.Type{
+		"topic":      types.StringType,
+		"server_url": types.StringType,
+		"token":      types.StringType,
+	}
+	plannedObj, _ := types.ObjectValue(attrTypes, map[string]attr.Value{
+		"topic":      types.StringValue("alerts"),
+		"server_url": types.StringValue("https://ntfy.example.com"),
+		"token":      types.StringValue("tk_planned"),
+	})
+	plannedList, _ := types.ListValue(types.ObjectType{AttrTypes: attrTypes}, []attr.Value{plannedObj})
+
+	api := apiNotification{
+		ID:       "1",
+		Name:     "ntfy",
+		Provider: "NOTIFICATION_PROVIDER_NTFY",
+		Data: map[string]interface{}{
+			"ntfy": map[string]interface{}{
+				"topic":     "alerts",
+				"serverUrl": "https://ntfy.example.com",
+				// token intentionally omitted, matching real API behavior.
+			},
+		},
+	}
+	data := notificationModel{Ntfy: plannedList}
+
+	diags := notificationAPIToModel(context.Background(), api, &data)
+	if diags.HasError() {
+		t.Fatalf("unexpected diags: %v", diags)
+	}
+	elems := data.Ntfy.Elements()
+	if len(elems) != 1 {
+		t.Fatalf("Ntfy length = %d, want 1", len(elems))
+	}
+	obj, ok := elems[0].(types.Object)
+	if !ok {
+		t.Fatalf("element is %T, want types.Object", elems[0])
+	}
+	tok, ok := obj.Attributes()["token"].(types.String)
+	if !ok {
+		t.Fatalf("token is %T, want types.String", obj.Attributes()["token"])
+	}
+	if got := tok.ValueString(); got != "tk_planned" {
+		t.Errorf("token = %q, want %q (the planned value was lost)", got, "tk_planned")
+	}
+}
+
+func TestNotificationAPIToModel_NtfyUsesAPITokenIfPresent(t *testing.T) {
+	// If the API ever starts echoing the token back, that takes priority
+	// over whatever data already holds.
+	api := apiNotification{
+		ID:       "1",
+		Provider: "NOTIFICATION_PROVIDER_NTFY",
+		Data: map[string]interface{}{
+			"ntfy": map[string]interface{}{
+				"topic": "alerts",
+				"token": "tk_api",
+			},
+		},
+	}
+	var data notificationModel
+	diags := notificationAPIToModel(context.Background(), api, &data)
+	if diags.HasError() {
+		t.Fatalf("unexpected diags: %v", diags)
+	}
+	obj, ok := data.Ntfy.Elements()[0].(types.Object)
+	if !ok {
+		t.Fatalf("element is %T, want types.Object", data.Ntfy.Elements()[0])
+	}
+	tok, ok := obj.Attributes()["token"].(types.String)
+	if !ok {
+		t.Fatalf("token is %T, want types.String", obj.Attributes()["token"])
+	}
+	if got := tok.ValueString(); got != "tk_api" {
+		t.Errorf("token = %q, want %q", got, "tk_api")
+	}
+}
+
 func rawKeys(m map[string]json.RawMessage) []string {
 	ks := make([]string, 0, len(m))
 	for k := range m {


### PR DESCRIPTION
…y.token (#19)

Two distinct provider-produces-inconsistent-result aborts surfaced by the same workspace's terraform apply:

- openstatus_http_monitor: the OpenStatus API echoes a placeholder empty header (`headers: [{}]`) when no headers are configured. The read-back mapper now drops `{Key:"", Value:""}` entries before writing state, so block count matches the plan. Real headers (any non-empty key or value) are unaffected; out-of-band drift detection still works because the filter is per-element, not all-or-nothing.

- openstatus_notification (ntfy): two related bugs.
  1. `server_url` and `token` are Optional but were decoded into plain `string`, which the framework rejects for null values ("Received null value, however the target type cannot handle null values"). Switched to types.String.
  2. The API does not echo ntfy.token in its response (Sensitive default). The read-back mapper now preserves the planned types.String — null stays null, value stays value — so post-apply state matches what Terraform planned and avoids "inconsistent values for sensitive attribute". API value still wins if ever returned.

Each fix has unit tests covering the placeholder/null/round-trip cases.